### PR TITLE
Fecha y Hora en la creación y actualización de tareas

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,7 +20,10 @@ configDotenv();
 const app = express();
 app.use(cors({ 
   credentials: true,
-  origin: process.env.FRONTEND_URL || 'http://localhost:5173'
+  origin: process.env.FRONTEND_URL || 'http://localhost:5173',
+  methods: ['GET', 'POST', 'PUT', 'DELETE'],
+  allowedHeaders: ['Content-Type', 'Authorization'],
+  exposedHeaders: ['set-cookie']
 }));
 app.use(express.urlencoded({ extended: true }));
 app.use(express.json());

--- a/src/controllers/taskController.js
+++ b/src/controllers/taskController.js
@@ -31,16 +31,21 @@ export const getTasks = async (req, res) => {
 
 export const createTask = async (req, res) => {
   try {
-    const { title, details, status = "Por Hacer" } = req.body;
+    const { title, details, status = "Por Hacer", date } = req.body;
 
     if (!title || !title.trim()) {
       return res.status(400).json({ message: "El título es obligatorio" });
+    }
+
+    if (date && new Date(date) < new Date()) {
+      return res.status(400).json({ message: "La fecha de finalización no puede ser anterior a hoy." });
     }
 
     const newTask = new Task({
       title,
       details,
       status,
+      date,
       user: req.user.id,
     });
    const savedTask = await newTask.save();
@@ -84,13 +89,18 @@ export const deleteTask = async (req, res) => {
 
 export const updateTask = async (req, res) => {
   try {
-    const { title, details, status } = req.body;
+    const { title, details, status, date } = req.body;
     if (!title || !title.trim()) {
       return res.status(400).json({ message: "El título es obligatorio" });
     }
+
+    if (date && new Date(date) < new Date()) {
+      return res.status(400).json({ message: "La fecha de finalización no puede ser anterior a hoy." });
+    }
+
     const taskUpdated = await Task.findOneAndUpdate(
       { _id: req.params.id, user: req.user.id },
-      { title, details, status },
+      { title, details, status, date },
       { new: true }
     );
     if (!taskUpdated) {

--- a/src/controllers/taskController.js
+++ b/src/controllers/taskController.js
@@ -66,11 +66,12 @@ export const deleteTask = async (req, res) => {
     if (!deletedTask)
       return res.status(404).json({ message: "Task not found" });
 
-    return res.status(204);
+    return res.status(200).json({ message: "Task deleted successfully" });
   } catch (error) {
     return res.status(500).json({ message: error.message });
   }
 };
+
 
 /**
  * Updates an existing task by its ID.

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -41,9 +41,9 @@ export const registerUser = async (req, res) => {
     // Establecer cookie con el token
     res.cookie("token", token, {
       httpOnly: true,
-      secure: true,
-      sameSite: "none",
-    });
+      secure: process.env.NODE_ENV === 'production', // solo true en producción
+      sameSite: process.env.NODE_ENV === 'production' ? "none" : "lax",
+  });
 
 
     res.status(201).json({
@@ -84,9 +84,10 @@ export const loginUser = async (req, res) => {
 
     res.cookie("token", token, {
       httpOnly: true,
-      secure: true,
-      sameSite: "none",
+      secure: process.env.NODE_ENV === 'production', // solo true en producción
+      sameSite: process.env.NODE_ENV === 'production' ? "none" : "lax",
     });
+    
 
     res.status(200).json({
       id: userFound._id,

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -41,6 +41,8 @@ export const registerUser = async (req, res) => {
     // Establecer cookie con el token
     res.cookie("token", token, {
       httpOnly: true,
+      secure: true,
+      sameSite: "none",
     });
 
 
@@ -82,6 +84,8 @@ export const loginUser = async (req, res) => {
 
     res.cookie("token", token, {
       httpOnly: true,
+      secure: true,
+      sameSite: "none",
     });
 
     res.status(200).json({
@@ -198,7 +202,8 @@ export const updateUser = async (req, res) => {
 export const logout = async (req, res) => {
   res.cookie("token", "", {
     httpOnly: true,
-
+    secure: true,
+    sameSite: "none",
     expires: new Date(0),
   });
   return res.status(200);

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -233,7 +233,8 @@ export const forgotPassword = async (req, res) => {
   user.resetPasswordExpires = Date.now() + 60 * 60 * 1000;
   await user.save();
 
-  const resetLink = `${process.env.FRONTEND_URL}/reset?token=${token}`;
+  
+  const resetLink = `${process.env.FRONTEND_URL}/reset-password?token=${token}`;
   await sendResetEmail(user.email, resetLink);
   //console.log(`Enviar email a ${email} con link: ${resetLink}`);
 

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -206,7 +206,7 @@ export const logout = async (req, res) => {
     sameSite: "none",
     expires: new Date(0),
   });
-  return res.status(200);
+  return res.sendStatus(200);
 };
 
 /**

--- a/src/models/Task.js
+++ b/src/models/Task.js
@@ -7,6 +7,7 @@ import mongoose from "mongoose";
  * @property {string} title - Title of the task.
  * @property {string} details - Detailed description of the task.
  * @property {string} status - Status of the task (e.g., 'Pending', 'Completed').
+ * @property {Date} date - Due date of the task.
  * @property {mongoose.Schema.Types.ObjectId} user - Reference to the user who owns the task.
  * @property {Date} createdAt - Date when the task was created (auto-managed).
  * @property {Date} updatedAt - Date when the task was last updated (auto-managed).
@@ -20,6 +21,7 @@ const taskSchema = new mongoose.Schema(
       enum: ["Por Hacer", "Haciendo", "Hecho"],
       default: "Por Hacer",
     },
+    date: { type: Date },
     user: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
   },
   { timestamps: true }


### PR DESCRIPTION
This pull request introduces support for a due date (`date`) field in tasks, along with validation to prevent setting a due date in the past. Additionally, it updates the password reset link to use a new URL path. The most important changes are grouped below:

### Task due date support and validation

* Added a new `date` field to the `Task` model schema and documentation, allowing tasks to store a due date. [[1]](diffhunk://#diff-1b4fe119560c2ffe83929208e641a5ea002aa2de8b83df62cff86aed296b9416R10) [[2]](diffhunk://#diff-1b4fe119560c2ffe83929208e641a5ea002aa2de8b83df62cff86aed296b9416R24)
* Updated the `createTask` and `updateTask` controllers to accept a `date` field and validate that the due date is not set in the past, returning an error if it is. [[1]](diffhunk://#diff-116ee6b2de2b75dd1a929f2b31fb5b5c32d38345423c881c77accda9fcf4ff44L34-R48) [[2]](diffhunk://#diff-116ee6b2de2b75dd1a929f2b31fb5b5c32d38345423c881c77accda9fcf4ff44L87-R103)

### Password reset link update

* Changed the password reset link in the `forgotPassword` controller to use `/reset-password` instead of `/reset` for improved clarity and consistency.